### PR TITLE
fix a crash when the device doesn't support RAW

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.gradle/
+.idea/
+Application/Application.iml
+Application/build/
+android-Camera2Raw.iml
+build/
+local.properties

--- a/Application/build.gradle
+++ b/Application/build.gradle
@@ -1,14 +1,3 @@
-
-buildscript {
-    repositories {
-        jcenter()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
-    }
-}
-
 apply plugin: 'com.android.application'
 
 repositories {
@@ -35,7 +24,7 @@ List<String> dirs = [
 
 android {
     
-        compileSdkVersion 26
+    compileSdkVersion 26
 
     buildToolsVersion "26.0.1"
 

--- a/Application/src/main/java/com/example/android/camera2raw/Camera2RawFragment.java
+++ b/Application/src/main/java/com/example/android/camera2raw/Camera2RawFragment.java
@@ -1039,7 +1039,7 @@ public class Camera2RawFragment extends Fragment
     private void configureTransform(int viewWidth, int viewHeight) {
         Activity activity = getActivity();
         synchronized (mCameraStateLock) {
-            if (null == mTextureView || null == activity) {
+            if (null == mTextureView || null == activity || mCharacteristics == null) {
                 return;
             }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,13 @@
+buildscript {
+    repositories {
+        jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
+    }
 
-
-
-
-
-
-
-
-
-
+    dependencies {
+        classpath 'com.android.tools.build:gradle:2.3.3'
+    }
+}


### PR DESCRIPTION
fix the crash:

```
10-12 17:58:54.841 13484-13484/com.example.android.camera2raw E/AndroidRuntime: FATAL EXCEPTION: main
        Process: com.example.android.camera2raw, PID: 13484
        java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Object android.hardware.camera2.CameraCharacteristics.get(android.hardware.camera2.CameraCharacteristics$Key)' on a null object reference
            at com.example.android.camera2raw.Camera2RawFragment.configureTransform(Camera2RawFragment.java:1046)
            at com.example.android.camera2raw.Camera2RawFragment.access$000(Camera2RawFragment.java:121)
            at com.example.android.camera2raw.Camera2RawFragment$1.onSurfaceTextureAvailable(Camera2RawFragment.java:212)
....
```