### PR TITLE
Fix error: Not found common.jar when build

### DIFF
--- a/Application/build.gradle
+++ b/Application/build.gradle
@@ -1,8 +1,8 @@
 
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 
     dependencies {
@@ -13,8 +13,8 @@ buildscript {
 apply plugin: 'com.android.application'
 
 repositories {
-    jcenter()
     google()
+    jcenter()
 }
 
 dependencies {


### PR DESCRIPTION
It was failed when build because couldn't find `common.jar` as below. 

```
Could not find common.jar (android.arch.core:common:1.0.0).
Searched in the following locations:
    https://jcenter.bintray.com/android/arch/core/common/1.0.0/common-1.0.0.jar
```

`jcenter()` needs to come after `google()`.